### PR TITLE
Fixes #76 and #77

### DIFF
--- a/XCode/GordianServer-macOS/Helpers/UrlRequest.swift
+++ b/XCode/GordianServer-macOS/Helpers/UrlRequest.swift
@@ -11,7 +11,7 @@ import Foundation
 class FetchLatestRelease {
         
     class func get(completion: @escaping ((dict:NSDictionary?, error:String?)) -> Void) {
-        let url = "https://api.github.com/repos/bitcoin/bitcoin/tags"
+        let url = "https://api.github.com/repos/bitcoin/bitcoin/releases"
         guard let destination = URL(string: url) else { return }
         let request = URLRequest(url: destination)
         let session = URLSession.shared
@@ -22,7 +22,7 @@ class FetchLatestRelease {
                         if let jsonArray = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSArray {
                             if jsonArray.count > 0 {
                                 if let latestTag = jsonArray[0] as? NSDictionary {
-                                    if let version = latestTag["name"] as? String {
+                                    if let version = latestTag["tag_name"] as? String {
                                         let processedVersion = version.replacingOccurrences(of: "v", with: "")
                                         let dict = [
                                             "version":"\(processedVersion)",

--- a/XCode/GordianServer-macOS/Scripts/StandUp.command
+++ b/XCode/GordianServer-macOS/Scripts/StandUp.command
@@ -57,9 +57,9 @@ function installBitcoin () {
 
     echo "Signatures do not match! Terminating..."
     exit 1
-    
+
   fi
-  
+
 }
 
 function configureBitcoin () {

--- a/XCode/GordianServer-macOS/Scripts/UpgradeBitcoin.command
+++ b/XCode/GordianServer-macOS/Scripts/UpgradeBitcoin.command
@@ -12,12 +12,12 @@ mkdir ~/.standup
 mkdir ~/.standup/BitcoinCore
 
 echo "Downloading $SHA_URL"
-curl $SHA_URL -o ~/StandUp/BitcoinCore/SHA256SUMS.asc -s
-echo "Saved to ~/StandUp/BitcoinCore/SHA256SUMS.asc"
+curl $SHA_URL -o ~/.standup/BitcoinCore/SHA256SUMS.asc -s
+echo "Saved to ~/.standup/BitcoinCore/SHA256SUMS.asc"
 
 echo "Downloading Laanwj PGP signature from https://bitcoin.org/laanwj-releases.asc..."
-curl https://bitcoin.org/laanwj-releases.asc -o ~/StandUp/BitcoinCore/laanwj-releases.asc -s
-echo "Saved to ~/StandUp/BitcoinCore/laanwj-releases.asc"
+curl https://bitcoin.org/laanwj-releases.asc -o ~/.standup/BitcoinCore/laanwj-releases.asc -s
+echo "Saved to ~/.standup/BitcoinCore/laanwj-releases.asc"
 
 echo "Downloading Bitcoin Core $VERSION from $MACOS_URL"
 cd ~/.standup/BitcoinCore


### PR DESCRIPTION
Now we fetch the latest release of Bitcoin Core instead of the latest tag from the github api to avoid issues of missing signatures.