### PR TITLE
Remove signature verification from Installation script

### DIFF
--- a/GordianServer-macOS/Scripts/StandUp.command
+++ b/GordianServer-macOS/Scripts/StandUp.command
@@ -6,8 +6,6 @@
 #  Created by Peter on 07/11/19.
 #  Copyright © 2019 Blockchain Commons, LLC
 
-GPG_PATH="$(command -v gpg)"
-
 function setUpGordianDir() {
     if ! [ -d ~/.gordian ]; then
         mkdir ~/.gordian
@@ -44,78 +42,20 @@ function installBitcoin() {
   echo $ACTUAL_SHA
   echo $EXPECTED_SHA
   
-  if [ "$ACTUAL_SHA" == "$EXPECTED_SHA" ]; then
-    echo "Hashes match"
-    echo "Checking Signatures"
-    verifySigs
-    
-  else
-    echo "Hashes do not match! Terminating..."
-    exit 1
-  fi
-}
-
-function verifySigs() {
-  echo "Downloading Bitcoin Core developer pgp keys from https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/builder-keys/keys.txt"
-  echo "Saving them to ~/.gordian/BitcoinCore/keys.txt"
-  
-  curl https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/builder-keys/keys.txt -o ~/.gordian/BitcoinCore/keys.txt
-  
-  if [[ $GPG_PATH == "" ]]; then
-    echo "GPG is not installed, ensure you have Homebrew installed by clicking Supported Apps in the menu bar > Homebrew"
-    echo "Once Homebrew installation completes open a terminal and run:"
-    echo "brew install gpg2 pinentry-mac"
-    echo "Unpacking $BINARY_NAME"
-    tar -zxvf $BINARY_NAME
-    configureBitcoin
-  else
-    checkPermissions
-  fi
-}
-
-function checkPermissions() {
-  GNUPG_PERMISSIONS=$(ls -ld /Users/$(whoami)/.gnupg)
-  CRLSD_PERMISSIONS=$(ls -ld /Users/$(whoami)/.gnupg/crls.d)
-    
-  if [[ $GNUPG_PERMISSIONS == drwx* ]] && [[ $CRLSD_PERMISSIONS == drwx* ]]; then
-    verifyNow
-  else
-    echo "***INCORRECT Permissions set on /Users/$(whoami)/.gnupg***"
-    echo $GNUPG_PERMISSIONS
-    echo "Permissions set on /Users/$(whoami)/.gnupg/crls.d:"
-    echo $CRLSD_PERMISSIONS
-    echo "In order to import keys to verify signatures .gnupg and .gnupg/crls.d needs to be set with chmod 700 (drwx)"
-    echo "Open a terminal, copy and paste the below commands, press enter, then use the Verify button to check signatures."
-    echo "-------------------------------------------------"
-    echo "sudo chown -R $(whoami):admin ~/.gnupg/"
-    echo "find ~/.gnupg -type d -exec sudo chmod 700 {} \;"
-    echo "find ~/.gnupg -type f -exec sudo chmod 600 {} \;"
-    echo "-------------------------------------------------"
-    echo "Unpacking $BINARY_NAME"
-    tar -zxvf $BINARY_NAME
-    configureBitcoin
-  fi
-}
-    
-function verifyNow() {
-    sh -c 'while read fingerprint keyholder_name; do sudo -u $(whoami) $(command -v gpg) --keyserver hkps://keys.openpgp.org --recv-keys ${fingerprint}; done < ~/.gordian/BitcoinCore/keys.txt'
-    
-    echo "Verifying Bitcoin Core signatures... (this can take a few moments)"
-
-    export SHASIG=`sudo -u $(whoami) $GPG_PATH --verify ~/.gordian/BitcoinCore/SHA256SUMS.asc ~/.gordian/BitcoinCore/SHA256SUMS 2>&1 | grep "Good signature"`
-    export SHACOUNT=`sudo -u $(whoami) $GPG_PATH --verify ~/.gordian/BitcoinCore/SHA256SUMS.asc ~/.gordian/BitcoinCore/SHA256SUMS 2>&1 | grep "Good signature" | wc -l`
-  
-    echo "SHASIG: $SHASIG"
-
-    if [[ "$SHASIG" ]]; then
-      echo "SIG VERIFICATION SUCCESS: $SHACOUNT GOOD SIGNATURES FOUND."
+  if [ "$ACTUAL_SHA" != "" ]; then
+    if [ "$ACTUAL_SHA" == "$EXPECTED_SHA" ]; then
+      echo "Hashes match"
       echo "Unpacking $BINARY_NAME"
       tar -zxvf $BINARY_NAME
       configureBitcoin
     else
-      echo "SIG VERIFICATION ERROR: No verified signatures for Bitcoin!"
+      echo "Hashes do not match! Terminating..."
       exit 1
     fi
+  else
+    echo "No hash exists, Bitcoin Core download failed..."
+    exit 1
+  fi
 }
 
 function configureBitcoin() {

--- a/GordianServer-macOS/View Controllers/Settings.swift
+++ b/GordianServer-macOS/View Controllers/Settings.swift
@@ -103,7 +103,7 @@ class Settings: NSViewController, NSTextFieldDelegate {
     @IBAction func goPrivate(_ sender: Any) {
         let value = goPrivateOutlet.state
         if value == .on {
-            actionAlert(message: "Go private?", info: "Your node will only accept connections over the Tor network, this can make initial block download very slow, it is recommended to go private once your node is fully synced.") { [unowned vc = self] (response) in
+            actionAlert(message: "Go private?", info: "Your node will only accept connections over the Tor network, this can make initial block download very slow, it is recommended to go private once your node is fully synced.") { [unowned vc = self] response in
                 if response {
                     vc.privateOn()
                 } else {
@@ -142,8 +142,8 @@ class Settings: NSViewController, NSTextFieldDelegate {
                             
                         case "discover", "#discover":
                             discoverExists = true
-                            if existingValue == "1" {
-                                stringConf = stringConf.replacingOccurrences(of: "\(k + "=" + existingValue)", with: "discover=0")
+                            if existingValue == "0" {
+                                stringConf = stringConf.replacingOccurrences(of: "\(k + "=" + existingValue)", with: "discover=1")
                             }
                             
                         case "#proxy", "proxy":
@@ -164,7 +164,7 @@ class Settings: NSViewController, NSTextFieldDelegate {
                 }
                 
                 if !discoverExists {
-                    stringConf = "discover=0\n" + stringConf
+                    stringConf = "discover=1\n" + stringConf
                 }
 
                 if !proxyExists {


### PR DESCRIPTION
This PR: 
- segregates signature verification from the install script, we still check hashes before unpacking the tarball, verification can be done via the `Verify` button
- checks that the Bitcoin Core binary did in fact download before attempting to compare hashes, previously if the `curl` command failed we would compare to empty strings as hashes and then attempt to unpack a tarball that did not exist
- fine tunes our `go private` feature to allow incoming connections over Tor (previously incoming connections would have been disabled completely)

