### PR TITLE
Fixes for Bitcoin Core 23

### DIFF
--- a/GordianServer-macOS.xcodeproj/project.pbxproj
+++ b/GordianServer-macOS.xcodeproj/project.pbxproj
@@ -793,7 +793,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.0.2;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "GordianServer-macOS/Info.plist";
@@ -802,7 +802,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.gordianserver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -818,7 +818,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.0.2;
 				DEVELOPMENT_TEAM = YZHG975W3A;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "GordianServer-macOS/Info.plist";
@@ -827,7 +827,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.blockchaincommons.gordianserver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/GordianServer-macOS/Base.lproj/Main.storyboard
+++ b/GordianServer-macOS/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -458,7 +458,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController storyboardIdentifier="MainWindow" id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Gordian Server v1.0.1" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="Gordian Server v1.0.2" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" texturedBackground="YES"/>
                         <windowPositionMask key="initialPositionMask" topStrut="YES"/>
                         <rect key="contentRect" x="226" y="275" width="436" height="480"/>

--- a/GordianServer-macOS/Helpers/Defaults.swift
+++ b/GordianServer-macOS/Helpers/Defaults.swift
@@ -173,9 +173,9 @@ class Defaults {
     }
     
     var existingBinary: String {
-        return ud.object(forKey: "macosBinary") as? String ?? "bitcoin-\(existingVersion)-osx64.tar.gz"
+        return ud.object(forKey: "macosBinary") as? String ?? "bitcoin-\(existingVersion)-x86_64-apple-darwin.tar.gz"
     }
-    
+
     var existingPrefix: String {
         return ud.object(forKey: "binaryPrefix") as? String ?? "bitcoin-\(existingVersion)"
     }

--- a/GordianServer-macOS/Helpers/Defaults.swift
+++ b/GordianServer-macOS/Helpers/Defaults.swift
@@ -169,7 +169,7 @@ class Defaults {
     }
     
     var existingVersion: String {
-        return ud.object(forKey: "version") as? String ?? "22.0"
+        return ud.object(forKey: "version") as? String ?? "23.0"
     }
     
     var existingBinary: String {

--- a/GordianServer-macOS/Helpers/UrlRequest.swift
+++ b/GordianServer-macOS/Helpers/UrlRequest.swift
@@ -27,8 +27,8 @@ class FetchLatestRelease {
                                         let dict = [
                                             "version":"\(processedVersion)",
                                             "binaryPrefix":"bitcoin-\(processedVersion)",
-                                            "macosBinary":"bitcoin-\(processedVersion)-osx64.tar.gz",
-                                            "macosURL":"https://bitcoincore.org/bin/bitcoin-core-\(processedVersion)/bitcoin-\(processedVersion)-osx64.tar.gz",
+                                            "macosBinary":"bitcoin-\(processedVersion)",
+                                            "macosURL":"https://bitcoincore.org/bin/bitcoin-core-\(processedVersion)/",
                                             "shaURL":"https://bitcoincore.org/bin/bitcoin-core-\(processedVersion)/SHA256SUMS",
                                             "shasumsSignedUrl":"https://bitcoincore.org/bin/bitcoin-core-\(processedVersion)/SHA256SUMS.asc"
                                         ] as NSDictionary

--- a/GordianServer-macOS/Info.plist
+++ b/GordianServer-macOS/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2021 Blockchain Commons. Licensed under BSD-2-Clause Plus Patent License unless otherwise noted.</string>
+	<string>Copyright © 2022 Blockchain Commons. Licensed under BSD-2-Clause Plus Patent License unless otherwise noted.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/GordianServer-macOS/Scripts/StandUp.command
+++ b/GordianServer-macOS/Scripts/StandUp.command
@@ -12,6 +12,10 @@ SHA_URL=$3
 SIGS_URL=$4
 VERSION=$5
 
+MAC_ARCH=`uname -m`
+BINARY_NAME="${BINARY_NAME}-${MAC_ARCH}-apple-darwin.tar.gz"
+MACOS_URL="${MACOS_URL}${BINARY_NAME}"
+
 function installBitcoin() {
   echo "Downloading $SHA_URL"
   curl $SHA_URL -o ~/.gordian/BitcoinCore/SHA256SUMS -s
@@ -27,7 +31,7 @@ function installBitcoin() {
 
   echo "Checking sha256 checksums $BINARY_NAME against provided SHA256SUMS"
   ACTUAL_SHA=$(shasum -a 256 $BINARY_NAME | awk '{print $1}')
-  EXPECTED_SHA=$(grep osx64 SHA256SUMS | awk '{print $1}')
+  EXPECTED_SHA=$(grep "${MAC_ARCH}-apple-darwin.tar.gz" SHA256SUMS | awk '{print $1}')
 
   echo "See two hashes (they should match):"
   echo $ACTUAL_SHA

--- a/GordianServer-macOS/Scripts/StandUp.command
+++ b/GordianServer-macOS/Scripts/StandUp.command
@@ -12,9 +12,15 @@ SHA_URL=$3
 SIGS_URL=$4
 VERSION=$5
 
-MAC_ARCH=`uname -m`
+# MAC_ARCH=`uname -m`
+# Currently the arm64 bitcoind exits with an Error: 9 on a M1
+# When this is resolved, the Defaults file in Helpers should be updated too
+
+MAC_ARCH="x86_64"
+
 BINARY_NAME="${BINARY_NAME}-${MAC_ARCH}-apple-darwin.tar.gz"
 MACOS_URL="${MACOS_URL}${BINARY_NAME}"
+
 
 function installBitcoin() {
   echo "Downloading $SHA_URL"


### PR DESCRIPTION
This PR fixes installation procedures to accommodate new file names for Bitcoin 23.0 and new division of Apple binaries into Intel and M1. It also partially updates defaults (which are not correctly updating, per #173).

It does _not_ currently:
(1) Update the defaults for the tar file name based on architecture & new naming
(2) Work on an M1 [it fails to find that Bitcoin Core is installed]

Thus, this PR is not yet ready to merge, but could be used in a pinch if a fresh Bitcoin Core 23.0 install was desired on an Intel Mac.